### PR TITLE
Add Kubernetes homelab Ansible playbook

### DIFF
--- a/homelab.yml
+++ b/homelab.yml
@@ -1,0 +1,143 @@
+---
+- name: Common configuration for all nodes
+  hosts: all
+  become: yes
+  vars:
+    pod_network_cidr: "192.168.0.0/16"
+  tasks:
+    - name: Disable swap
+      command: swapoff -a
+      when: ansible_swaptotal_mb > 0
+
+    - name: Remove swap from fstab
+      replace:
+        path: /etc/fstab
+        regexp: '^([^#].*\sswap\s)'
+        replace: '# \1'
+
+    - name: Load kernel modules
+      copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+
+    - name: Ensure kernel modules are loaded
+      shell: |
+        modprobe overlay
+        modprobe br_netfilter
+
+    - name: Apply sysctl params
+      copy:
+        dest: /etc/sysctl.d/k8s.conf
+        content: |
+          net.bridge.bridge-nf-call-iptables  = 1
+          net.ipv4.ip_forward                 = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+
+    - name: Reload sysctl
+      command: sysctl --system
+
+    - name: Install containerd
+      apt:
+        name: containerd
+        state: present
+        update_cache: yes
+
+    - name: Configure containerd default config
+      command: "containerd config default"
+      register: containerd_config
+      changed_when: false
+
+    - name: Write containerd config file
+      copy:
+        dest: /etc/containerd/config.toml
+        content: "{{ containerd_config.stdout }}"
+
+    - name: Enable systemd cgroup driver for containerd
+      replace:
+        path: /etc/containerd/config.toml
+        regexp: 'SystemdCgroup = false'
+        replace: 'SystemdCgroup = true'
+
+    - name: Restart containerd
+      systemd:
+        name: containerd
+        state: restarted
+        enabled: yes
+
+    - name: Add Kubernetes apt key
+      apt_key:
+        url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        state: present
+
+    - name: Add Kubernetes apt repository
+      apt_repository:
+        repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+        state: present
+
+    - name: Install Kubernetes packages
+      apt:
+        name:
+          - kubelet
+          - kubeadm
+          - kubectl
+        state: present
+        update_cache: yes
+
+    - name: Hold Kubernetes packages
+      apt:
+        name:
+          - kubelet
+          - kubeadm
+          - kubectl
+        state: present
+        mark_hold: yes
+
+- name: Configure master node
+  hosts: master
+  become: yes
+  vars:
+    pod_network_cidr: "192.168.0.0/16"
+  tasks:
+    - name: Initialize Kubernetes cluster
+      command: kubeadm init --pod-network-cidr={{ pod_network_cidr }} --ignore-preflight-errors=all
+      args:
+        creates: /etc/kubernetes/admin.conf
+      register: kubeadm_init
+
+    - name: Set kube config for root
+      command: |
+        mkdir -p $HOME/.kube
+        cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+        chown $(id -u):$(id -g) $HOME/.kube/config
+      when: kubeadm_init.changed
+
+    - name: Install Calico CNI
+      command: kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+      when: kubeadm_init.changed
+
+    - name: Install Longhorn
+      command: kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+      when: kubeadm_init.changed
+
+    - name: Get join command
+      command: kubeadm token create --print-join-command
+      register: join_command
+
+    - name: Set fact for worker join
+      set_fact:
+        worker_join_cmd: "{{ join_command.stdout }}"
+
+- name: Join worker nodes
+  hosts: workers
+  become: yes
+  tasks:
+    - name: Join node to cluster
+      command: "{{ hostvars[groups['master'][0]].worker_join_cmd }} --ignore-preflight-errors=all"
+      args:
+        creates: /etc/kubernetes/kubelet.conf

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,0 +1,10 @@
+[master]
+master ansible_host=192.168.56.10
+
+[workers]
+worker1 ansible_host=192.168.56.11
+worker2 ansible_host=192.168.56.12
+
+[all:vars]
+ansible_user=ubuntu
+ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
## Summary
- add inventory example with master and workers
- add `homelab.yml` playbook to install containerd, Kubernetes, Calico and Longhorn

## Testing
- `ansible-playbook --syntax-check -i inventory.ini homelab.yml`

------
https://chatgpt.com/codex/tasks/task_e_6866fd4ae8888327bf1605ee3b63352c