### PR TITLE
Add k3s cluster setup with addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # k8s-ansible
+
+Deze repository bevat Ansible playbooks om een k3s-cluster op te zetten op drie Ubuntu-nodes.
+
+## Bestandsoverzicht
+
+- `inventory.ini` – definieert de `controlplane` en `workers`
+- `install-k3s.yaml` – installeert k3s op alle nodes
+- `addons.yaml` – installeert Cert-Manager, Longhorn en NGINX Ingress via Helm
+- `roles/k3s` – rol voor installatie van k3s
+- `roles/addons` – rol voor installatie van de helm-addons
+
+## Gebruik
+
+1. Installeer benodigde collections:
+
+```bash
+ansible-galaxy collection install kubernetes.core community.kubernetes
+```
+
+2. Installeer k3s op de nodes:
+
+```bash
+ansible-playbook -i inventory.ini install-k3s.yaml
+```
+
+De kubeconfig van de controlplane wordt in de map `kubeconfig` op de controller geplaatst.
+
+3. Installeer de addons:
+
+```bash
+ansible-playbook -i inventory.ini addons.yaml
+```

--- a/addons.yaml
+++ b/addons.yaml
@@ -1,0 +1,6 @@
+---
+- name: Deploy Kubernetes addons
+  hosts: controlplane
+  become: yes
+  roles:
+    - addons

--- a/install-k3s.yaml
+++ b/install-k3s.yaml
@@ -1,0 +1,16 @@
+---
+- name: Install k3s on control plane
+  hosts: controlplane
+  become: yes
+  roles:
+    - role: k3s
+      vars:
+        k3s_role: server
+
+- name: Install k3s on worker nodes
+  hosts: workers
+  become: yes
+  roles:
+    - role: k3s
+      vars:
+        k3s_role: agent

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,9 +1,9 @@
-[master]
-master ansible_host=192.168.56.10
+[controlplane]
+node1 ansible_host=192.168.56.10
 
 [workers]
-worker1 ansible_host=192.168.56.11
-worker2 ansible_host=192.168.56.12
+node2 ansible_host=192.168.56.11
+node3 ansible_host=192.168.56.12
 
 [all:vars]
 ansible_user=ubuntu

--- a/roles/addons/meta/main.yml
+++ b/roles/addons/meta/main.yml
@@ -1,0 +1,9 @@
+galaxy_info:
+  author: example
+  description: Install Kubernetes addons via Helm
+  min_ansible_version: 2.14
+  license: MIT
+
+collections:
+  - kubernetes.core
+  - community.kubernetes

--- a/roles/addons/tasks/main.yml
+++ b/roles/addons/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Install cert-manager
+  kubernetes.core.helm:
+    name: cert-manager
+    chart_repo_url: https://charts.jetstack.io
+    chart_ref: cert-manager
+    release_namespace: cert-manager
+    create_namespace: true
+    release_values:
+      installCRDs: true
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+
+- name: Install Longhorn
+  kubernetes.core.helm:
+    name: longhorn
+    chart_repo_url: https://charts.longhorn.io
+    chart_ref: longhorn
+    release_namespace: longhorn-system
+    create_namespace: true
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+
+- name: Install NGINX Ingress Controller
+  kubernetes.core.helm:
+    name: ingress-nginx
+    chart_repo_url: https://kubernetes.github.io/ingress-nginx
+    chart_ref: ingress-nginx
+    release_namespace: ingress-nginx
+    create_namespace: true
+    kubeconfig: /etc/rancher/k3s/k3s.yaml

--- a/roles/k3s/meta/main.yml
+++ b/roles/k3s/meta/main.yml
@@ -1,0 +1,9 @@
+galaxy_info:
+  author: example
+  description: Install k3s
+  min_ansible_version: 2.14
+  license: MIT
+
+collections:
+  - kubernetes.core
+  - community.kubernetes

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Download k3s install script
+  get_url:
+    url: https://get.k3s.io
+    dest: /tmp/k3s_install.sh
+    mode: '0755'
+
+- name: Install k3s server
+  shell: INSTALL_K3S_EXEC="--disable traefik" sh /tmp/k3s_install.sh
+  args:
+    creates: /usr/local/bin/k3s
+  when: k3s_role == 'server'
+
+- name: Get join token
+  slurp:
+    src: /var/lib/rancher/k3s/server/node-token
+  register: token_file
+  delegate_to: "{{ groups['controlplane'][0] }}"
+  run_once: true
+  when: k3s_role == 'agent'
+
+- name: Set token fact
+  set_fact:
+    server_token: "{{ token_file.content | b64decode }}"
+  when: k3s_role == 'agent'
+
+- name: Install k3s agent
+  shell: |
+    K3S_URL=https://{{ hostvars[groups['controlplane'][0]].ansible_host | default(groups['controlplane'][0]) }}:6443 \
+    K3S_TOKEN={{ server_token }} sh /tmp/k3s_install.sh
+  args:
+    creates: /usr/local/bin/k3s
+  when: k3s_role == 'agent'
+
+- name: Download kubeconfig
+  fetch:
+    src: /etc/rancher/k3s/k3s.yaml
+    dest: ./kubeconfig
+    flat: yes
+  when: k3s_role == 'server'


### PR DESCRIPTION
## Summary
- provision k3s on controlplane and worker nodes
- deploy addons Cert-Manager, Longhorn, and ingress-nginx
- include new roles for k3s and addons
- document usage in README

## Testing
- `ansible-playbook -i inventory.ini install-k3s.yaml --syntax-check`
- `ansible-playbook -i inventory.ini addons.yaml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_686a646937088327a50c3bfb2b4fb29e