### PR TITLE
Install Helm via addons role

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deze repository bevat Ansible playbooks om een k3s-cluster op te zetten op drie 
 
 - `inventory.ini` – definieert de `controlplane` en `workers`
 - `install-k3s.yaml` – installeert k3s op alle nodes
-- `addons.yaml` – installeert Cert-Manager, Longhorn en NGINX Ingress via Helm
+- `addons.yaml` – installeert Cert-Manager, Longhorn en NGINX Ingress via Helm (Helm wordt automatisch geïnstalleerd)
 - `roles/k3s` – rol voor installatie van k3s
 - `roles/addons` – rol voor installatie van de helm-addons
 

--- a/roles/addons/tasks/main.yml
+++ b/roles/addons/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Install Helm
+  apt:
+    name: helm
+    state: present
+    update_cache: yes
+
 - name: Install cert-manager
   kubernetes.core.helm:
     name: cert-manager


### PR DESCRIPTION
## Summary
- install Helm before deploying addons
- mention automatic Helm installation in README

## Testing
- `ansible-playbook -i inventory.ini addons.yaml --syntax-check`
- `ansible-playbook -i inventory.ini install-k3s.yaml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_686a68d371d483279926f6b9df02cfea