### PR TITLE
Install helm via official apt repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deze repository bevat Ansible playbooks om een k3s-cluster op te zetten op drie 
 
 - `inventory.ini` – definieert de `controlplane` en `workers`
 - `install-k3s.yaml` – installeert k3s op alle nodes
-- `addons.yaml` – installeert Cert-Manager, Longhorn en NGINX Ingress via Helm (Helm wordt automatisch geïnstalleerd)
+- `addons.yaml` – installeert Cert-Manager, Longhorn en NGINX Ingress via Helm (Helm wordt via de officiële apt-repository geïnstalleerd)
 - `roles/k3s` – rol voor installatie van k3s
 - `roles/addons` – rol voor installatie van de helm-addons
 

--- a/roles/addons/tasks/main.yml
+++ b/roles/addons/tasks/main.yml
@@ -1,9 +1,30 @@
 ---
+- name: Install apt-transport-https
+  apt:
+    name: apt-transport-https
+    state: present
+    update_cache: yes
+
+- name: Add Helm GPG key
+  shell: |
+    curl https://baltocdn.com/helm/signing.asc | gpg --dearmor > /usr/share/keyrings/helm.gpg
+  args:
+    creates: /usr/share/keyrings/helm.gpg
+
+- name: Add Helm apt repository
+  shell: |
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" > /etc/apt/sources.list.d/helm-stable-debian.list
+  args:
+    creates: /etc/apt/sources.list.d/helm-stable-debian.list
+
+- name: Update apt cache for Helm repository
+  apt:
+    update_cache: yes
+
 - name: Install Helm
   apt:
     name: helm
     state: present
-    update_cache: yes
 
 - name: Install cert-manager
   kubernetes.core.helm:


### PR DESCRIPTION
## Summary
- install apt-transport-https and add Helm apt repository using official instructions
- update README to mention Helm install source

## Testing
- `ansible-playbook --syntax-check install-k3s.yaml`
- `ansible-playbook --syntax-check addons.yaml`
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6cec60b88327963d0dffca1afee5